### PR TITLE
remove compiler warnings

### DIFF
--- a/main/gps.h
+++ b/main/gps.h
@@ -39,7 +39,8 @@ String setupGPS()
       // a tricky thing here is if we print the NMEA sentence, or data
       // we end up not listening and catching other sentences!
       // so be very wary if using OUTPUT_ALLDATA and trying to print out data
-      c = GPS.lastNMEA(); //this gives an error but doesn't seem to be an issue
+      c = *GPS.lastNMEA(); //unclear what this statement does. Variable is unused atm
+      (void) c;
       if (!GPS.parse(GPS.lastNMEA())){} // this also sets the newNMEAreceived() flag to false
     }
     if(timer < millis()){
@@ -82,7 +83,8 @@ gpsReading getGPS()
       // a tricky thing here is if we print the NMEA sentence, or data
       // we end up not listening and catching other sentences!
       // so be very wary if using OUTPUT_ALLDATA and trying to print out data
-      c = GPS.lastNMEA(); //this gives an error but doesn't seem to be an issue
+      c = *GPS.lastNMEA(); //unclear what this statement does. Variable is unused atm
+      (void) c;
       if (!GPS.parse(GPS.lastNMEA())){} // this also sets the newNMEAreceived() flag to false
     }
   }

--- a/main/gy521_imu.h
+++ b/main/gy521_imu.h
@@ -15,6 +15,8 @@ imuReading getIMU()
   imuSample.time = micros(); //current timestamp
   int16_t AcX, AcY, AcZ, GyX, GyY, GyZ, Tmp;
 
+  (void) Tmp; //we can remove this if we decide to record temperature from the IMU
+
   Wire.beginTransmission(MPU);
   Wire.write(0x3B);
   Wire.endTransmission(false);

--- a/main/main.ino
+++ b/main/main.ino
@@ -53,16 +53,18 @@ void loop()
   static int tick = 0;
   static flightPhase status = ONPAD;
   unsigned int tickTime = getTickTime(status);
+  int x = 1;
+  (void) x;
   if(status == POST_FLIGHT){
     while(millis() - lastTime < tickTime/1000){
       //waste time
-      int x = 1 + 1;
+      x = x;
     }
     lastTime = millis();
   } else {
     while(micros() - lastTime < tickTime){
       //waste time
-      int x = 1 + 1;
+      x = x;
     }
     lastTime = micros();
   }


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
We have multiple compiler warnings, which does not satisfy our requirement of `0` errors and `0` warnings on `main`. Most of the warnings refer to unused variables. One of the warnings involved converting a pointer to a char, and probably would have been an error if we didn't happen to not be using the variable.

1. `main/gy521_imu.h:16:41: warning: variable 'Tmp' set but not used [-Wunused-but-set-variable]`
1. `main/gps.h:85:23: warning: invalid conversion from 'char*' to 'char' [-fpermissive]`

## Solution
- The unused variable warnings occurred from variables that we are purposely not using
  - we could silence these with `(void) var`
- For the incorrect conversion error I was simply able to correct the conversion. It's unclear if this will affect behavior of the GPS readings

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. compiled code, ran a unit test, loaded onto physical microcontroller etc.)-->
- compiled code with no errors or warnings

## Additional Testing
- during the throw test we will need to verify that the GPS still works #55 

closes #54 