### PR TITLE
Changed to HLA contributors only

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ Designed for Teensy 4.1
 
 Want to contribute? Start [here](https://github.com/Harlem-Launch-Alliance/Catalyst-2/blob/main/GETTING_STARTED.md).
 
+NOTE: At this time we are only accepting contributions from [HLA](hla.nyc) members.
+
 [Instructions for use](https://github.com/Harlem-Launch-Alliance/Catalyst-2#instructions-for-use)
 
 ## Goals:


### PR DESCRIPTION
- Added a comment in the readme saying that we'll only accept contributions from HLA members. This is to prevent random people from making advanced changes that newer members might not be able to keep up with.