### PR TITLE
issue50, changed all instances of buzzer to buzzerPin

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -17,7 +17,7 @@
 
 // Constants:
 #define SEALEVELPRESSURE_HPA (1013.25)
-const int buzzer = 33;
+const int buzzerPin = 33;
 unsigned long lastTime = 0;
 
 // Variables:
@@ -25,12 +25,12 @@ bool apogeeReached;
 
 void setup()
 {
-  pinMode(buzzer, OUTPUT);    // Set buzzer pin as an output
+  pinMode(buzzerPin, OUTPUT);    // Set buzzer pin as an output
   for(int i = 0; i < 5; i++)  // Play 5 beeps
   {
-    tone(buzzer, 1000);       // Send 1KHz sound signal...
+    tone(buzzerPin, 1000);       // Send 1KHz sound signal...
     delay(1000);              // ...for 1 sec
-    noTone(buzzer);           // Stop sound...
+    noTone(buzzerPin);           // Stop sound...
     delay(1000);              // ...for 1sec
   }
   Wire.begin();               // initiate wire library and I2C


### PR DESCRIPTION
issue 50, "buzzer" pin to more descriptive "buzzerPin"

## Description of Problem
In main.ino line 20 a variable called buzzer is defined. This variable name is misleading, since the datatype is not actually a buzzer, rather it's a buzzer pin number. As such the variable should have its name changed from buzzer to something more descriptive.

## Solution
Variable name was changed to buzzerPin. The name was also updated in all other locations where it is called
`closes #50 `

## Testing
- compiled code with no errors or warnings

COMPILER LOG

Processing teensy41 (platform: teensy; board: teensy41; framework: arduino)
--------------------------------------------------------------------------------------------------------------Verbose mode can be enabled via `-v, --verbose` option
CONFIGURATION: https://docs.platformio.org/page/boards/teensy/teensy41.html
PLATFORM: Teensy (4.17.0) > Teensy 4.1
HARDWARE: IMXRT1062 600MHz, 512KB RAM, 7.75MB Flash
DEBUG: Current (jlink) External (jlink)
PACKAGES:
 - framework-arduinoteensy @ 1.157.220801 (1.57) 
 - tool-teensy @ 1.157.0 (1.57)
 - toolchain-gccarmnoneeabi @ 1.50401.190816 (5.4.1)
Converting main.ino
LDF: Library Dependency Finder -> https://bit.ly/configure-pio-ldf
LDF Modes: Finder ~ chain, Compatibility ~ soft
Found 97 compatible libraries
Scanning dependencies...
Dependency Graph
|-- EWMA @ 1.0.2
|-- Adafruit BMP3XX Library @ 2.1.2
|   |-- Adafruit BusIO @ 1.13.2
|   |   |-- Wire @ 1.0
|   |   |-- SPI @ 1.0
|   |-- Wire @ 1.0
|   |-- SPI @ 1.0
|-- Adafruit GPS Library @ 1.7.0
|   |-- SPI @ 1.0
|   |-- Wire @ 1.0
|-- SD @ 2.0.0
|   |-- SdFat @ 2.1.2
|   |   |-- SPI @ 1.0
|-- Wire @ 1.0
Building in release mode
Compiling .pio\build\teensy41\src\main.ino.cpp.o
Compiling .pio\build\teensy41\libc12\EWMA\Ewma.cpp.o
Compiling .pio\build\teensy41\libfb4\Wire\Wire.cpp.o
Compiling .pio\build\teensy41\libfb4\Wire\WireIMXRT.cpp.o
Compiling .pio\build\teensy41\libfb4\Wire\WireKinetis.cpp.o
Compiling .pio\build\teensy41\libfb4\Wire\utility\twi.c.o
Compiling .pio\build\teensy41\lib2f8\SPI\SPI.cpp.o
Compiling .pio\build\teensy41\libdab\Adafruit BusIO\Adafruit_BusIO_Register.cpp.o
Compiling .pio\build\teensy41\libdab\Adafruit BusIO\Adafruit_I2CDevice.cpp.o
Compiling .pio\build\teensy41\libdab\Adafruit BusIO\Adafruit_SPIDevice.cpp.o
Compiling .pio\build\teensy41\lib4be\Adafruit BMP3XX Library\Adafruit_BMP3XX.cpp.o
Compiling .pio\build\teensy41\lib4be\Adafruit BMP3XX Library\bmp3.c.o
Archiving .pio\build\teensy41\libc12\libEWMA.a
Compiling .pio\build\teensy41\lib733\Adafruit GPS Library\Adafruit_GPS.cpp.o
In file included from C:/Users/Renato/Documents/git/Catalyst-2/main/main.ino:13:0:
main\gy521_imu.h: In function 'imuReading getIMU()':
main\gy521_imu.h:16:41: warning: variable 'Tmp' set but not used [-Wunused-but-set-variable]
   int16_t AcX, AcY, AcZ, GyX, GyY, GyZ, Tmp;
                                         ^
In file included from C:/Users/Renato/Documents/git/Catalyst-2/main/main.ino:15:0:
main\gps.h: In function 'String setupGPS()':
main\gps.h:42:23: warning: invalid conversion from 'char*' to 'char' [-fpermissive]
       c = GPS.lastNMEA(); //this gives an error but doesn't seem to be an issue
                       ^
main\gps.h:36:10: warning: variable 'c' set but not used [-Wunused-but-set-variable]
     char c = GPS.read();
          ^
In file included from C:/Users/Renato/Documents/git/Catalyst-2/main/main.ino:15:0:
main\gps.h: In function 'gpsReading getGPS()':
main\gps.h:85:23: warning: invalid conversion from 'char*' to 'char' [-fpermissive]
       c = GPS.lastNMEA(); //this gives an error but doesn't seem to be an issue
                       ^
main\gps.h:79:10: warning: variable 'c' set but not used [-Wunused-but-set-variable]
     char c = GPS.read();
          ^
C:/Users/Renato/Documents/git/Catalyst-2/main/main.ino: In function 'void loop()':
C:/Users/Renato/Documents/git/Catalyst-2/main/main.ino:59:11: warning: unused variable 'x' [-Wunused-variable]       int x = 1 + 1;
           ^
C:/Users/Renato/Documents/git/Catalyst-2/main/main.ino:65:11: warning: unused variable 'x' [-Wunused-variable]       int x = 1 + 1;
           ^
Compiling .pio\build\teensy41\lib733\Adafruit GPS Library\NMEA_build.cpp.o
Compiling .pio\build\teensy41\lib733\Adafruit GPS Library\NMEA_data.cpp.o
Compiling .pio\build\teensy41\lib733\Adafruit GPS Library\NMEA_parse.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\ExFatLib\ExFatDbg.cpp.o
Archiving .pio\build\teensy41\libfb4\libWire.a
Compiling .pio\build\teensy41\lib35a\SdFat\ExFatLib\ExFatFile.cpp.o
Archiving .pio\build\teensy41\libdab\libAdafruit BusIO.a
Compiling .pio\build\teensy41\lib35a\SdFat\ExFatLib\ExFatFilePrint.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\ExFatLib\ExFatFileWrite.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\ExFatLib\ExFatFormatter.cpp.o
Archiving .pio\build\teensy41\lib4be\libAdafruit BMP3XX Library.a
Compiling .pio\build\teensy41\lib35a\SdFat\ExFatLib\ExFatName.cpp.o
Archiving .pio\build\teensy41\lib2f8\libSPI.a
Compiling .pio\build\teensy41\lib35a\SdFat\ExFatLib\ExFatPartition.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\ExFatLib\ExFatVolume.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\ExFatLib\upcase.cpp.o
Archiving .pio\build\teensy41\lib733\libAdafruit GPS Library.a
Compiling .pio\build\teensy41\lib35a\SdFat\FatLib\FatDbg.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FatLib\FatFile.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FatLib\FatFileLFN.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FatLib\FatFilePrint.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FatLib\FatFileSFN.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FatLib\FatFormatter.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FatLib\FatName.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FatLib\FatPartition.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FatLib\FatVolume.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FreeStack.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FsLib\FsFile.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FsLib\FsNew.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\FsLib\FsVolume.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\MinimumSerial.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SdCard\SdCardInfo.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SdCard\SdSpiCard.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SdCard\SdioTeensy.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SpiDriver\SdSpiArtemis.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SpiDriver\SdSpiChipSelect.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SpiDriver\SdSpiDue.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SpiDriver\SdSpiESP.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SpiDriver\SdSpiParticle.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SpiDriver\SdSpiSTM32.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SpiDriver\SdSpiSTM32Core.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\SpiDriver\SdSpiTeensy3.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\common\FmtNumber.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\common\FsCache.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\common\FsDateTime.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\common\FsGetPartitionInfo.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\common\FsName.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\common\FsStructs.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\common\FsUtf.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\common\PrintBasic.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\common\upcase.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\iostream\StdioStream.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\iostream\StreamBaseClass.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\iostream\istream.cpp.o
Compiling .pio\build\teensy41\lib35a\SdFat\iostream\ostream.cpp.o
Compiling .pio\build\teensy41\libbee\SD\SD.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\AudioStream.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\CrashReport.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\DMAChannel.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\EventResponder.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\HardwareSerial.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\HardwareSerial1.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\HardwareSerial2.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\HardwareSerial3.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\HardwareSerial4.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\HardwareSerial5.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\HardwareSerial6.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\HardwareSerial7.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\HardwareSerial8.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\IPAddress.cpp.o
Archiving .pio\build\teensy41\lib35a\libSdFat.a
Compiling .pio\build\teensy41\FrameworkArduino\IntervalTimer.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\Print.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\Stream.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\Time.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\Tone.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\WMath.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\WString.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\analog.c.o
Compiling .pio\build\teensy41\FrameworkArduino\bootdata.c.o
Compiling .pio\build\teensy41\FrameworkArduino\clockspeed.c.o
Compiling .pio\build\teensy41\FrameworkArduino\debugprintf.c.o
Compiling .pio\build\teensy41\FrameworkArduino\delay.c.o
Archiving .pio\build\teensy41\libbee\libSD.a
Compiling .pio\build\teensy41\FrameworkArduino\digital.c.o
Compiling .pio\build\teensy41\FrameworkArduino\eeprom.c.o
Compiling .pio\build\teensy41\FrameworkArduino\extmem.c.o
Compiling .pio\build\teensy41\FrameworkArduino\fuse.c.o
Compiling .pio\build\teensy41\FrameworkArduino\interrupt.c.o
Compiling .pio\build\teensy41\FrameworkArduino\keylayouts.c.o
Compiling .pio\build\teensy41\FrameworkArduino\main.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\memcpy-armv7m.S.o
Compiling .pio\build\teensy41\FrameworkArduino\memset.S.o
Compiling .pio\build\teensy41\FrameworkArduino\new.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\nonstd.c.o
Compiling .pio\build\teensy41\FrameworkArduino\pwm.c.o
Compiling .pio\build\teensy41\FrameworkArduino\rtc.c.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEvent.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEvent1.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEvent2.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEvent3.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEvent4.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEvent5.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEvent6.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEvent7.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEvent8.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEventUSB1.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\serialEventUSB2.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_alloc_valid.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_calloc.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_free.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_hash.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_malloc.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_malloc_stats.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_pool.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_realloc.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_realloc_i.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_realloc_move.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_szalloc.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_util.c.o
Compiling .pio\build\teensy41\FrameworkArduino\sm_zalloc.c.o
Compiling .pio\build\teensy41\FrameworkArduino\startup.c.o
Compiling .pio\build\teensy41\FrameworkArduino\tempmon.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_audio.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_desc.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_flightsim.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_inst.cpp.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_joystick.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_keyboard.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_midi.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_mouse.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_mtp.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_rawhid.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_seremu.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_serial.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_serial2.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_serial3.c.o
Compiling .pio\build\teensy41\FrameworkArduino\usb_touch.c.o
Compiling .pio\build\teensy41\FrameworkArduino\yield.cpp.o
Archiving .pio\build\teensy41\libFrameworkArduino.a
Linking .pio\build\teensy41\firmware.elf
Checking size .pio\build\teensy41\firmware.elf
Calculating size .pio\build\teensy41\firmware.elf
Building .pio\build\teensy41\firmware.hex
teensy_size: Memory Usage on Teensy 4.1:
teensy_size:   FLASH: code:92544, data:12428, headers:8688   free for files:8012804
teensy_size:    RAM1: variables:378016, code:89304, padding:9000   free for local variables:47968
teensy_size:    RAM2: variables:12384  free for malloc/new:511904
======================================== [SUCCESS] Took 6.14 seconds ========================================
 *  Terminal will be reused by tasks, press any key to close it. 