### PR TITLE
Fix Acceleration Modifier

### DIFF
--- a/main/gy521_imu.h
+++ b/main/gy521_imu.h
@@ -33,9 +33,9 @@ imuReading getIMU()
   GyY=Wire.read()<<8|Wire.read();
   GyZ=Wire.read()<<8|Wire.read();
   
-  imuSample.accel.x = AcX/16384.0;
-  imuSample.accel.y = AcY/16384.0;
-  imuSample.accel.z = AcZ/16384.0;
+  imuSample.accel.x = AcX/4096.0;
+  imuSample.accel.y = AcY/4096.0;
+  imuSample.accel.z = AcZ/4096.0;
   imuSample.gyro.x = toRad(GyX/131.0);
   imuSample.gyro.y = toRad(GyZ/131.0);
   imuSample.gyro.z = toRad(GyY/131.0); //IMU's Y corresponds to rocket's Z axis due to orientation on PCB


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
The modifier on raw acceleration data was assuming we had a sensitivity of +- 2g instead of +- 8g. This resulted in acceleration data being off by a factor of 4. Net stationary acceleration was ~0.25g.

## Solution
The modifier was updated to `4096` in accordance with [MPU 6050 spec sheet](https://invensense.tdk.com/wp-content/uploads/2015/02/MPU-6000-Datasheet1.pdf)

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. compiled code, ran a unit test, loaded onto physical microcontroller etc.)-->
- compiled code with no errors or warnings
- deployed code onto Catalyst-2 and verified that acceleration values seemed feasible

closes #64 