### PR TITLE
Assign result of run functions

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -71,17 +71,17 @@ void loop()
 
   switch(status){
   case ONPAD:
-    runOnPad(tick);
+    status = runOnPad(tick);
     break;
   case ASCENDING:
-    runAscending(tick);
+    status = runAscending(tick);
     break;
   case DESCENDING:
-    runDescending(tick);
+    status = runDescending(tick);
     break;
   case POST_FLIGHT:
   default:
-    runPostFlight(tick);
+    status = runPostFlight(tick);
   }
   tick++;
 }


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
Each of the run functions (`runOnPad()` etc.) returns the next state after each call. However, this value isn't assigned to anything, so the state is never updated. The symptom of this was that Catalyst continued to assume it was on the pad even though launch had been detected.

## Solution
By assigning the result of each run function to `status`, Catalyst will be able to properly identify its current state.

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. compiled code, ran a unit test, loaded onto physical microcontroller etc.)-->
- compiled code with no errors or warnings
- performed a throw test and observed transitions between all 4 states #51 

closes #65 