### PR TITLE
Change use of reserved word in a variable to a non-reserved word

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -132,7 +132,7 @@ flightPhase runAscending(int tick){ //this will run similarly to ONPAD except ha
   //sample sensors
   static bmpReading lastBmp;
   static gpsReading lastGps;
-  static unsigned int delay = 0;
+  static unsigned int transitionDelay = 0;
   bool apogeeReached = false;
   imuReading imuSample = getIMU(); //sample IMU first to maximize consistency
   
@@ -151,10 +151,10 @@ flightPhase runAscending(int tick){ //this will run similarly to ONPAD except ha
   if(tick % 5 == 1){//20 times per second with a slight offset to avoid overlapping with bmp and gps
     transmitData(lastBmp.altitude, lastGps, '1');
   }
-  if(apogeeReached && !delay){
-    delay = millis() + 3000;//added 3 second delay incase chute deploy is late
+  if(apogeeReached && !transitionDelay){
+    transitionDelay = millis() + 3000;//added 3 second delay incase chute deploy is late
   }
-  if(apogeeReached && delay > millis())
+  if(apogeeReached && transitionDelay > millis())
     return DESCENDING;
   return ASCENDING;
 }


### PR DESCRIPTION

<!-- Please Give Your PR a relevant title-->

## Description of Problem
<!-- Clearly describe the problem you're solving-->
Function runAscending() does not work the intended way due to the variable "delay" inside of it.
## Solution
<!-- Describe your thought process and the steps you took to find a solution. If your process resulted in a new issue being created, link it here-->
Changed all instances of variable delay under the function runAscending() to transitionDelay. The variable was previously not working because delay is a reserved word, meaning that it already has a function set to it. Instead, transitionDelay works since it has no function set to it.

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. compiled code, ran a unit test, loaded onto physical microcontroller etc.)-->
- compiled code with no errors or warnings