### PR TITLE
Record Flight Phase to SD

### DIFF
--- a/main/data.h
+++ b/main/data.h
@@ -78,12 +78,14 @@ void backupToSD(){
     double altitude = 0;
     double latitude = 0;
     double longitude = 0;
+    int state = -1; //use invalid state when declared so that it's clear if something isn't working right
     imuReading imuSample = imuQueue.peek();
     imuQueue.dequeue();
     if(!bmpQueue.isEmpty()){
       bmpReading bmpSample = bmpQueue.peek();
       if(bmpSample.time < imuSample.time){
         altitude = bmpSample.altitude;
+        state = bmpSample.state;
         bmpQueue.dequeue();
       }
     }
@@ -113,8 +115,10 @@ void backupToSD(){
     dataFile.print(imuSample.accel.z); dataFile.print(',');
     dataFile.print(imuSample.attitude.x); dataFile.print(',');
     dataFile.print(imuSample.attitude.y); dataFile.print(',');
-    dataFile.print(imuSample.attitude.z); dataFile.println(',');
-    //TODO add state
+    dataFile.print(imuSample.attitude.z); dataFile.print(',');
+    if(altitude != 0)
+      dataFile.print(state);
+    dataFile.println(',');
   }
   while(!bmpQueue.isEmpty()){
     double latitude = 0;
@@ -145,6 +149,8 @@ void backupToSD(){
     dataFile.print(',');
     dataFile.print(',');
     dataFile.print(',');
+    dataFile.print(',');
+    dataFile.print(bmpSample.state);
     dataFile.println(',');
   }
   dataFile.close(); 

--- a/main/main.ino
+++ b/main/main.ino
@@ -96,6 +96,7 @@ flightPhase runOnPad(int tick){
   bool hasLaunched = detectLaunch(imuSample.accel); //might need to calibrate accel data before feeding to this function
   if(tick % 5 == 0){
     lastBmp = getBMP();
+    lastBmp.state = 0; //this corresponds to ONPAD
     detectApogee(imuSample.accel, lastBmp.altitude, hasLaunched); //need to run this prelaunch to get calibrations
     recordData(lastBmp, true);
   }
@@ -138,6 +139,7 @@ flightPhase runAscending(int tick){ //this will run similarly to ONPAD except ha
   
   if(tick % 5 == 0){
     lastBmp = getBMP();
+    lastBmp.state = 1; //this corresponds to ASCENDING
     apogeeReached = detectApogee(imuSample.accel, lastBmp.altitude, true);
     recordData(lastBmp, false);
   }
@@ -165,6 +167,7 @@ flightPhase runDescending(int tick){//this runs at 20hz
 
   //sample sensors
   bmpReading bmpSample = getBMP();
+  bmpSample.state = 2; //this corresponds to DESCENDING
   recordData(bmpSample, false);
 
   if(tick % 20 == 1){//still one time per second
@@ -187,7 +190,7 @@ flightPhase runDescending(int tick){//this runs at 20hz
 
 flightPhase runPostFlight(int tick){//this runs at 1hz 
   //once we're on the ground we can stop recording and start just broadcasting GPS somewhat infrequently
-  static bmpReading bmpSample = getBMP();
+  static bmpReading bmpSample = getBMP(); //no need to add a state to this sample since it won't be recorded
   if(tick % 5 == 0){//broadcast every 5 seconds
     gpsReading gpsSample = getGPS();
     transmitData(bmpSample.altitude, gpsSample, '3');

--- a/main/utils.h
+++ b/main/utils.h
@@ -25,6 +25,7 @@ struct bmpReading //all data from an altimeter reading
 {
   double altitude;
   unsigned long time;
+  unsigned short state; //used for tracking flightPhase (0-3 representing ONPAD - POST_FLIGHT)
 };
 
 struct imuReading //all data from an IMU reading (accelerometer and gyroscope)


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
It's currently relatively easy to infer what state the computer is in (what main function is running). However, it'll speed up any debugging to be able to easily see exactly when state changes occur. We are already transmitting flight state, so it shouldn't add much complexity to record it on the SD card as well.

## Solution
While it's not 100% intuitive, I added the flight state as member data in the `bmpReading` struct. This is useful because this struct is already being used to both record and transmit data (altitude). By adding the flight state to this struct, we have easy access to that data in the places that we need it (run functions and data recording functions). Our current configuration stops recording data after the transition to `POST_FLIGHT`, so rather than recording that state I think we can simply infer that the EOF relays that the computer is in that state.

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. compiled code, ran a unit test, loaded onto physical microcontroller etc.)-->
- compiled code with no errors or warnings
- ran this configuration during throw tests and viewed data recording to the SD card

closes #27 