### PR TITLE
Removed EWMA from apogee detection

### DIFF
--- a/main/apogee.h
+++ b/main/apogee.h
@@ -33,20 +33,19 @@ bool isAccelerating(Directional accel){//determine if we are accelerating at mor
 
 bool detectApogee(Directional accel, double altitude, bool hasLaunched){ //accel in Gs
   static bool apogeeReached = false; //this is initialized as false, but once it flips to true it should remain true until the arduino is reset
-  static Ewma altFilter(.05); //this will contain a filtered altitude (less prone to noise)
   static int counter = 0;
-  static double lastAlt = altitude;
   counter = (counter + 1) % 5; //this will count from 0 to 4, overflowing back to 0
-  double currentAlt = altFilter.filter(altitude);
+  static double lastAlt = altitude;
   
   if(apogeeReached)//if apogee was already detected earlier we don't need to do any more math
     return true;
-  
+
   if(counter == 0){
     //everytime counter overflows we check for apogee (4hz at the moment, this should be a constant or tied to a constant)
-    if(hasLaunched && currentAlt < lastAlt && !isAccelerating(accel))
+    if(hasLaunched && altitude < lastAlt  && !isAccelerating(accel)){
       apogeeReached = true;
-    lastAlt = currentAlt;
+    }
+    lastAlt = altitude;
   }
   return apogeeReached;
 }


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
During throw tests #85 #55 we encountered a software crash that occurred on about half of tests. We were able to localize this crash to the apogee detection function, but where unable to find a definitive reason for the crash. When reviewing the code it all seemed to be reasonable.

## Solution
After increasing our confidence that the crash was occurring in `detectApogee()`, we decided that it might save time to simply rewrite the function without using EWMA to test if that would work. After making the change, we performed 4 more throw tests and were unable to reproduce the previous crashing issue. We determined that our changes likely solved the issue.

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. compiled code, ran a unit test, loaded onto physical microcontroller etc.)-->
- compiled code with no errors or warnings
- tested on 4 throw tests and observed nominal operation

## Discussion
- In addition to resolving the bug, we found that the new software was consistently able to detect apogee with much greater precision than the previous version
- we do have some concerns that this function may be more prone to false positives. As such, it may be beneficial to add more security checks to verify the rocket's current state (such as monitoring velocity and recent acceleration events)

closes #92 
closes 