### PR TITLE
Rearranged inclusions to appease intellisense

### DIFF
--- a/main/apogee.h
+++ b/main/apogee.h
@@ -5,6 +5,8 @@
 
 #include <Ewma.h> //https://github.com/jonnieZG/EWMA
 #include "settings.h"
+#include "utils.h"
+
 #define G_FORCE_TO_LAUNCH 3 //if acceleration exceeds this number the rocket will assume it has been launched
 #define MAX_APOGEE_ACCEL 2 //we can rule out apogee if acceleration is about this amount (Gs)
 //#define CHECK_FOR_APOGEE_HZ 4 //frequency that we check for apogee within the detect apogee function

--- a/main/attitude.h
+++ b/main/attitude.h
@@ -8,6 +8,7 @@
 //assuming roll == 0, pitchRate will be equivalent to y, and yawRate will be equivalent to x
 
 #include <Ewma.h> //https://github.com/jonnieZG/EWMA
+#include "utils.h"
 
 //returns calculated pitchRate or yawRate
 double getRate(double roll, double parallel, double perpendicular){//if getting rateX, parallel should be x

--- a/main/bmp_altimeter.h
+++ b/main/bmp_altimeter.h
@@ -3,6 +3,9 @@
  * 
  ****************************************************************************/
 
+#include "Adafruit_BMP3XX.h"  // BMP388 library
+#include "utils.h"
+
 #define BMP_CS 10
 double GNDLEVELPRESSURE_HPA;
 

--- a/main/data.h
+++ b/main/data.h
@@ -3,6 +3,8 @@
  * currently using an SD card and Xbee respectively
  ****************************************************************************/
 #include "ringQueue.h"
+#include "utils.h"
+#include <SD.h>
 
 const int chipSelect = BUILTIN_SDCARD;
 char filename[50];

--- a/main/gps.h
+++ b/main/gps.h
@@ -2,6 +2,7 @@
 // Need to remove the GPS.lastNMEA() and see if it still works, still get compilation error
 
 #include <Adafruit_GPS.h>
+#include "utils.h"
 
 // what's the name of the hardware serial port?
 #define GPSSerial Serial2

--- a/main/gy521_imu.h
+++ b/main/gy521_imu.h
@@ -5,6 +5,7 @@
 
 #include <Wire.h> //library allows communication with I2C / TWI devices
 #include <math.h> //library includes mathematical functions
+#include "utils.h"
 
 const uint8_t MPU=0x68;                  //I2C address of the MPU-6050
 const double tcal = -1600;           //Temperature correction

--- a/main/main.ino
+++ b/main/main.ino
@@ -3,17 +3,13 @@
                             Recovery Systems Group 2021 - 2022
                               Catalyst 2.1 Flight Computer
  *************************************************************************************/
-#include <Wire.h>             // to communicate with I2C devices
-#include <SD.h>               // for data storage on the onboard microSD card
-#include "utils.h"
-#include "Adafruit_BMP3XX.h"  // BMP388 library
+
 #include "apogee.h"
 #include "bmp_altimeter.h"
 #include "data.h"
 #include "gy521_imu.h"
 #include "attitude.h"
 #include "gps.h"
-#include "ringQueue.h"
 
 // Constants:
 #define SEALEVELPRESSURE_HPA (1013.25)

--- a/main/utils.h
+++ b/main/utils.h
@@ -2,8 +2,11 @@
  * This file is for declaring utilities to be used in multiple other places
  * 
  ****************************************************************************/
-#include <math.h>
 #include "settings.h"
+#include <Arduino.h>
+
+#ifndef UTILS_H
+#define UTILS_H
 
 class Directional  //any data that has an x,y and z attribute
 {
@@ -65,3 +68,5 @@ int getTickTime(flightPhase phase){//map flight phases to tick times
   }
   return TICK_TIME_POST_FLIGHT;
 }
+
+#endif


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
Arduino code compiles differently than C++, but our linter (spell check for code) is designed for C++. If we want to use this linter (we do) we'll need to change our grammar to C++ grammar.

## Solution
Some files/libraries needed to be explicitly included in a few extra places. As a result we were also able to reduce the number of files included in `main.ino` since these would be recursively included anyway. I also added an empty `include` folder because platformIO expects one and causes the linter to give a warning when it's missing.

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. compiled code, ran a unit test, loaded onto physical microcontroller etc.)-->
- compiled code with no errors or warnings
- compiled code via Teensyduino application (seems to have slightly different compiler flags) to ensure backwards compatibility
- verified that the current executable is not substantially different in size from the previous version

closes #89 