### PR TITLE
changed counter type to reduce memory usage

### DIFF
--- a/main/attitude.h
+++ b/main/attitude.h
@@ -21,7 +21,7 @@ Directional calibrateGyro(Directional gyro, bool hasLaunched){//returns gyro off
   static Ewma zFilter(.002);
   static Directional lastSave;//0-5 second old data
   static Directional oldSave;//5-10 second old data
-  static int counter = 0;
+  static uint8_t counter = 0;
 
   if(hasLaunched){//once launch occurs we lock in the offsets (and return early to skip the math)
     //in order to offset the delay between launch and launch detection, we use the data from 5-10 seconds prior


### PR DESCRIPTION
## Description of Problem
The data type for the counter takes more memory space than we would like (which is as little as possible). Changing the data type would also make it more clear what type of values this variable will be. 

## Solution
Changed the data type for the counter from int to uint8_t which takes up less memory (by one byte). It also makes it clear that the values of this variable will be always be a small positive number. 

closes #98 

## Testing
- compiled code with no errors or warnings