### PR TITLE
changed all const to constexpr

### DIFF
--- a/main/settings.h
+++ b/main/settings.h
@@ -6,13 +6,13 @@
 #define SETTINGS_H
 
 //tick times (microseconds)
-const uint32_t TICK_TIME_ONPAD = 10000;
-const uint32_t TICK_TIME_ASCENDING = 10000;
-const uint32_t TICK_TIME_DESCENDING = 50000;
-const uint32_t TICK_TIME_POST_FLIGHT = 1000000;
+constexpr uint32_t TICK_TIME_ONPAD = 10000;
+constexpr uint32_t TICK_TIME_ASCENDING = 10000;
+constexpr uint32_t TICK_TIME_DESCENDING = 50000;
+constexpr uint32_t TICK_TIME_POST_FLIGHT = 1000000;
 
-const uint32_t RING_QUEUE_LENGTH = 3000;//each 100 elements is 1 seconds of data at 100hz
+constexpr uint32_t RING_QUEUE_LENGTH = 3000;//each 100 elements is 1 seconds of data at 100hz
 
-const uint32_t GPS_WAIT_TIME = 300; //number of seconds to wait for GPS to acquire signal before moving on
+constexpr uint32_t GPS_WAIT_TIME = 300; //number of seconds to wait for GPS to acquire signal before moving on
 
 #endif


### PR DESCRIPTION
## Description of Problem
We want to prevent any possible future bugs by limiting the flexibility of the compiler by changing the variable data type. 

## Solution
Replaced all const uses with constexpr to reduce flexibility of the compiler. 

## Testing
- compiled code with no errors or warnings

closes #102 