### PR TITLE
Declared lastTime inside void loop as static

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -13,7 +13,6 @@
 
 // Constants:
 const int buzzerPin = 33;
-unsigned long lastTime = 0;
 
 void setup()
 {
@@ -44,6 +43,7 @@ flightPhase runPostFlight(uint32_t tick);
 
 void loop()
 {
+  static long lastTime = 0;
   static uint32_t tick = 0;
   static flightPhase status = ONPAD;
   uint32_t tickTime = getTickTime(status);


### PR DESCRIPTION
## Description of Problem
The lastTime variable isn't used outside the scope of void loop and we want to prevent deallocations between function calls.

## Solution
Moved declaration of lastTime to within the void loop and declared it as a static variable to prevent deallocations between function calls.

## Testing
- compiled code with no errors or warnings

## Issues
closes #110 
