### PR TITLE
Fixed landing detection

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -153,7 +153,7 @@ flightPhase runAscending(uint32_t tick){ //this will run similarly to ONPAD exce
 
 flightPhase runDescending(uint32_t tick){//this runs at 20hz
   static gpsReading lastGps;
-  static int lastAlt = 0;
+  static int lastAlt = getBMP().altitude + 5;//initialize so that landing detection isn't triggered accidentally
 
   //sample sensors
   bmpReading bmpSample = getBMP();
@@ -170,7 +170,7 @@ flightPhase runDescending(uint32_t tick){//this runs at 20hz
   transmitData(bmpSample.altitude, lastGps, '2');
 
   if(tick % 100 == 3){//every 5 seconds check if we are still descending
-    if(bmpSample.altitude - lastAlt < 1){//if altitude hasn't changed more than 1 meter in 5 seconds, we're on the ground
+    if(lastAlt - bmpSample.altitude < 1){//if altitude hasn't changed more than 1 meter in 5 seconds, we're on the ground
       return POST_FLIGHT;
     }
     lastAlt = bmpSample.altitude;


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
As seen in a recent flight, landing detection was triggered early, midway through the rockets descent. This issue was thought to be a result of oversensitivity in the landing detection code.

## Solution
It turns out that we had a comparison flipped (`currentAlt - lastAlt` was supposed to be `lastAlt - currentAlt`). As a result of this flipped comparison, the computer determined that the rocket had landed the first time that the landing detection code was triggered.

After flipping the comparison, I also changed the initialization of `lastAlt` to a value *larger* than the current altitude to account for the change.

## Issues
closes #127 