### PR TITLE
added Werror build flag

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,7 @@ default_envs = teensy41
 platform = teensy
 board = teensy41
 framework = arduino
+build_flags = -Werror
 board_build.f_cpu = 600000000L
 lib_deps = 
 	adafruit/Adafruit BMP3XX Library@^2.1.2


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
Currently if our code has warnings in it, it'll still pass the build check. Ideally the build check would fail in this case because we don't want to have any warnings.

## Solution
<!-- Describe your thought process and the steps you took to find a solution. If your process resulted in a new issue being created, link it here-->
- added `-Werror` build flag
This flag tells the compiler to treat all warnings as errors. Thus if we have a warning the compiler will report an error and the build check will fail.