### PR TITLE
Changed gps telemetry be compatible with Catalyst-UI

### DIFF
--- a/main/data.h
+++ b/main/data.h
@@ -30,8 +30,7 @@ void transmitData(double altitude, gpsReading gps, char phase)
   Serial1.println(altitude,1);
 
   //gps packet
-  Serial1.print("2 ");
-  Serial1.print(" ");
+  Serial1.print("3 ");
   Serial1.print(gps.latitude, 4);
   Serial1.print(" ");
   Serial1.println(gps.longitude, 4);


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
<!-- Clearly describe the problem you're solving-->
As seen in the [Catalyst-UI spec](https://github.com/Harlem-Launch-Alliance/Catalyst-UI#specifications), the identifier for a GPS packet is `3`. This had been incorrectly configured on Catalyst.

*Perhaps these "magic strings" should be constants*

## Solution
<!-- Describe your thought process and the steps you took to find a solution. If your process resulted in a new issue being created, link it here-->
- changed identifier for GPS packet to `3`

## Testing
<!-- Describe the testing that you did to validate your changes (i.e. ran a unit test, loaded onto physical microcontroller etc.)-->
<!-- ex:
- Executed "throw test" on Catalyst to verify behavior
-->
- verified GPS display on UI with telemetry off of Catalyst