### PR TITLE
Added SD backup call at apogee and landing

### DIFF
--- a/main/main.ino
+++ b/main/main.ino
@@ -154,6 +154,12 @@ flightPhase runAscending(uint32_t tick){ //this will run similarly to ONPAD exce
 flightPhase runDescending(uint32_t tick){//this runs at 20hz
   static gpsReading lastGps;
   static double lastAlt = getBMP().altitude + 5;//initialize so that landing detection isn't triggered accidentally
+  static bool initialDump = false;
+
+  if(!initialDump) {
+    initialDump = true;
+    backupToSD();
+  }
 
   //sample sensors
   bmpReading bmpSample = getBMP();
@@ -178,7 +184,13 @@ flightPhase runDescending(uint32_t tick){//this runs at 20hz
   return DESCENDING;
 }
 
-flightPhase runPostFlight(uint32_t tick){//this runs at 1hz 
+flightPhase runPostFlight(uint32_t tick){//this runs at 1hz
+  static bool initialDump = false;
+
+  if(!initialDump) {
+    initialDump = true;
+    backupToSD();
+  }
   //once we're on the ground we can stop recording and start just broadcasting GPS somewhat infrequently
   static bmpReading bmpSample = getBMP(); //no need to add a state to this sample since it won't be recorded
   if(tick % 5 == 0){//broadcast every 5 seconds


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
<!-- Clearly describe the problem you're solving-->
Due to current hardware issues Catalyst tends to reboot as a result of the forces from the ejection charge. This causes a full data loss if no backups have occurred yet.

## Solution
<!-- Describe your thought process and the steps you took to find a solution. If your process resulted in a new issue being created, link it here-->
- Added a one time call to backup flight data as soon as apogee is detected.
  - this will ensure that the ascent flight data is backed up at the soonest possible opportunity
  - in the future this will likely need to be undone to allow for continued orientation tracking up until the point of the ejection charge.