### PR TITLE
Added flexibility to attitude calculation

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -3,13 +3,13 @@ This is the definitive guide to contributing any software to this repository. It
 
 ### Please read all steps even if you intend to skip them
 
-This document is a work in progress. Please contact the current avionics team lead if you have any feedback.
+This document is a work in progress. Please contact the current [avionics team lead](https://www.hla.nyc/club-leadership.html) if you have any feedback.
 
 ## Development Environment
 Some 3rd party software is required to make and validate changes. You will need to download all of the following software:
 
 ### Arduino IDE
-This IDE is required even if you plan on using a different one, since it also comes with all of the necessary libraries. [download](https://www.arduino.cc/en/software)
+This IDE is required even if you plan on using a different one, since it also comes with the Arduino compiler. [download](https://www.arduino.cc/en/software)
 
 ### Teensyduino
 This add-on allows the Arduino IDE and tooling to be compatible with our Teensy microcontroller. [download](https://www.pjrc.com/teensy/td_download.html)
@@ -17,10 +17,10 @@ This add-on allows the Arduino IDE and tooling to be compatible with our Teensy 
 ### VSCode
 VSCode is an IDE (integrated development environment) that provides tools to ease your development experience. [download](https://code.visualstudio.com/download)
 
-There are many other IDEs to choose from, but this documentation will be specific to VSCode.
+There are other IDEs to choose from, but this documentation will be specific to VSCode.
 
 ### PlatformIO and Python3
-Once you have VSCode installed, install Python3 and the `PlatformIO` extension. [This youtube tutorial](https://www.youtube.com/watch?v=JmvMvIphMnY) is very useful for getting familiarized with PlatformIO.
+Once you have VSCode installed, install [Python3](https://www.python.org/downloads/) and the `PlatformIO` extension. [This youtube tutorial](https://www.youtube.com/watch?v=JmvMvIphMnY) is very useful for getting familiarized with PlatformIO.
 
 ### Git
 Not to be confused with `GitHub`, `Git` is the protocol that we use to collaborate on our software. Your computer may already come with Git. 

--- a/main/Ewma.h
+++ b/main/Ewma.h
@@ -10,37 +10,35 @@
 * t : time 
 */ 
 
-#ifndef EWMA_H_
-#define EWMA_H_
+#pragma once
 
 class Ewma{
-public:
-	
-	double output = 0; //current output EWMA(t)
-	double alpha = 0; //smoothing factor
-
-	
-	Ewma(double alpha) { // constructs an Ewma filter with smoothing factor a
-		this->alpha = alpha;
-		} 
+public:	
+	/// @brief constructs an Ewma filter
+	/// @param newAlpha smoothing factor from [0,1] (higher alpha value causes less smoothing of datapoints)
+	Ewma(double newAlpha) {
+		alpha = newAlpha;
+	} 
 
 	void reset(){
-		this->hasInitial = false; 
+		hasInitial = false; 
 	}
 
-	double filter(double input){
+	void filter(const double input){
 		if (hasInitial) {
 			output = alpha * (input - output) + output;
 		} else {
 			output = input;
 			hasInitial = true;
 		}
+	}
+
+	double getOutput() {
 		return output;
 	}
 
 private:
-	bool hasInitial = false;
-
+	double alpha; //smoothing factor
+	bool hasInitial;
+	double output; //current output EWMA(t)
 };
-
-#endif

--- a/main/apogee.h
+++ b/main/apogee.h
@@ -29,8 +29,8 @@ bool detectLaunch(Directional accel){//accel in Gs
   //group all accels into one
   //accel may need calibration. If that is the case, it should happen externally and only calibrated data should enter this function
   double totalAccel = sqrt(pow(accel.x, 2) + pow(accel.y, 2) + pow(accel.z, 2)); //this should be 1G when stationary
-  
-  double filteredAccel = accelFilter.filter(totalAccel);
+  accelFilter.filter(totalAccel);
+  double filteredAccel = accelFilter.getOutput();
   if(filteredAccel > G_FORCE_TO_LAUNCH)
     hasLaunched = true;
   return hasLaunched;

--- a/main/attitude.h
+++ b/main/attitude.h
@@ -10,6 +10,20 @@
 #include "Ewma.h" 
 #include "utils.h"
 
+/// @brief this object tracks attitude/orientation as well as gyroscope calibration values
+class Attitude {
+public:
+  Attitude() = default;
+  void calibrateGyro(const Directional& rawGyro);
+  void updateAttitude(Directional gyro, const bool hasLaunched, const uint32_t sampleTime);
+  Directional getCurrentAttitude();
+private:
+  Directional m_attitude, m_zeroRateOffsets;
+  uint32_t m_lastSampleTime;
+  double getRate(const double roll, const double parallel, const double perpendicular);
+  void getCalibratedGyro(Directional& gyro);
+};
+
 //returns calculated pitchRate or yawRate
 /**
  * @brief Calculate Pitch or Yaw rate given raw inputs and current roll orientation
@@ -22,58 +36,46 @@
  * @param perpendicular raw rate in perpendicular direction (Y)
  * @return double actual rate in cardinal X direction
  */
-double getRate(double roll, double parallel, double perpendicular){//if getting rateX, parallel should be x
+double Attitude::getRate(const double roll, const double parallel, const double perpendicular)
+{ //if getting rateX, parallel should be x
   return parallel * cos(roll) + perpendicular * sin(roll);
 }
 
 /**
  * @brief Filter raw data through an EWMA to compute "Zero Rate Offset" for each axis
  * 
- * @param gyro One sample of the gyroscope
- * @param hasLaunched has the rocket launched yet
- * @return Directional current calculated zero rate offsets
+ * @param rawGyro One sample of the gyroscope
  */
-Directional calibrateGyro(Directional gyro, bool hasLaunched){//returns gyro offsets
+void Attitude::calibrateGyro(const Directional& rawGyro)
+{
+  static Directional lastSavedOffsets;
+  static int16_t tickCounter;
   static Ewma xFilter(.002);
   static Ewma yFilter(.002);
   static Ewma zFilter(.002);
-  static Directional lastSave;//0-5 second old data
-  static Directional oldSave;//5-10 second old data
-  static uint16_t counter = 0;
 
-  if(hasLaunched){//once launch occurs we lock in the offsets (and return early to skip the math)
-    //in order to offset the delay between launch and launch detection, we use the data from 5-10 seconds prior
-    return oldSave;
+  xFilter.filter(rawGyro.x);
+  yFilter.filter(rawGyro.y);
+  zFilter.filter(rawGyro.z);
+
+  tickCounter = (tickCounter + 1) % 500;
+  //every 500 ticks (2-5 seconds), we save the last state and transfer the previous state to the go queue
+  if(tickCounter == 0){
+    m_zeroRateOffsets = lastSavedOffsets;
+    lastSavedOffsets = Directional(xFilter.getOutput(), yFilter.getOutput(), zFilter.getOutput());
   }
-
-  Directional current;
-
-  current.x = xFilter.filter(gyro.x);
-  current.y = yFilter.filter(gyro.y);
-  current.z = zFilter.filter(gyro.z);
-
-  counter = (counter + 1) % 500;
-  //every 500 ticks (5 seconds), we save the last state and transfer the previous state to the go queue
-  if(counter == 0){
-    oldSave = lastSave;
-    lastSave = current;
-  }
-  return oldSave;
 }
 
 /**
- * @brief Given raw gyro data and zero rate offsets, determine actual rotation rates
+ * @brief normalize raw gyro data using zero rate offsets
  * 
- * @param gyro raw gyro sample
- * @param offsets vector of zero rate offsets
- * @return Directional actual rotation rates
+ * @param[in, out] gyro raw gyro sample
  */
-Directional getRealGyro(Directional gyro, Directional offsets){
-  Directional realGyro;
-  realGyro.x = gyro.x - offsets.x;
-  realGyro.y = gyro.y - offsets.y;
-  realGyro.z = gyro.z - offsets.z;
-  return realGyro;
+void Attitude::getCalibratedGyro(Directional& gyro)
+{
+  gyro.x = gyro.x - m_zeroRateOffsets.x;
+  gyro.y = gyro.y - m_zeroRateOffsets.y;
+  gyro.z = gyro.z - m_zeroRateOffsets.z;
 }
 
 /**
@@ -81,38 +83,46 @@ Directional getRealGyro(Directional gyro, Directional offsets){
  * 
  * @note In order to minimize error, we should assume that attitude is 0,0,0 at launch. However, 
  *  we don't actually know exactly when launch occurs. We can assume with almost 100% 
- *  certianty that launch is detected less than 5 seconds after it has actually occured, so 
- *  as a substitute, we can start recording attitude changes 5 seconds before detected 
- *  launch. In order to achieve this, we can record changes in 5 second increments (chunks) 
+ *  certainty that launch is detected less than 500 ticks (2-5 seconds) after it has actually occured, so 
+ *  as a substitute, we can start recording attitude changes 500 ticks before detected 
+ *  launch. In order to achieve this, we can record changes in 500 tick increments (chunks) 
  *  prior to launch. Once launch is detected we will 'lock in' those chunks and continue 
  *  recording changes forever.
  * 
- * @param gyro Calibrated gyro sample
+ * @param gyro raw gyro sample
  * @param hasLaunched has the rocket launched
- * @return Directional current attitude vector (Euler angles)
  */
-Directional getAttitude(Directional gyro, bool hasLaunched){//only calibrated gyro data should go in here
-  const int hz = 100; //number of readings per second
+void Attitude::updateAttitude(Directional gyro, const bool hasLaunched, uint32_t sampleTime)
+{
   static Directional oldChanges; //5-10 seconds ago
   static Directional lastChanges; //0-5 seconds ago
-  static uint16_t counter = 0;
-  Directional currentAttitude;
+  static uint16_t tickCounter = 0;
 
-  counter = (counter + 1) % 500;
+  getCalibratedGyro(gyro);
+  const uint32_t timeDiff = sampleTime - m_lastSampleTime;
+  m_lastSampleTime = sampleTime;
+  const double timeDiffSeconds = timeDiff / 1000000;
 
-  lastChanges.z += gyro.z/hz;
-  currentAttitude.z = oldChanges.z + lastChanges.z; //z must be set first so we can calculate x and y
-  lastChanges.x += getRate(currentAttitude.z/* -gyro.z/2 */, gyro.x, gyro.y)/hz; //TODO: test whether or not -gyro.z/2 makes a difference
-  lastChanges.y += getRate(currentAttitude.z/* -gyro.z/2 */, gyro.y, gyro.x)/hz;
-  currentAttitude.x = oldChanges.x + lastChanges.x;
-  currentAttitude.y = oldChanges.y + lastChanges.y;
+  tickCounter = (tickCounter + 1) % 500;
 
-  if(counter == 0 && !hasLaunched){//every 5 seconds we dump all data that's more than 5 seconds old (prior to launch)
+  lastChanges.z += gyro.z * timeDiffSeconds;
+  m_attitude.z = oldChanges.z + lastChanges.z; //z must be set first so we can calculate x and y
+  lastChanges.x += getRate(m_attitude.z/* -gyro.z/2 */, gyro.x, gyro.y) * timeDiffSeconds; //TODO: test whether or not -gyro.z/2 makes a difference
+  lastChanges.y += getRate(m_attitude.z/* -gyro.z/2 */, gyro.y, gyro.x) * timeDiffSeconds;
+  m_attitude.x = oldChanges.x + lastChanges.x;
+  m_attitude.y = oldChanges.y + lastChanges.y;
+
+  // every 5 seconds we delete all data that's more than 5 seconds old (prior to launch)
+  // this minimizes accumalation of error before launch
+  if(tickCounter == 0 && !hasLaunched){
     oldChanges = lastChanges;
     lastChanges.x = 0;
     lastChanges.y = 0;
     lastChanges.z = 0;
   }
+}
 
-  return currentAttitude;
+Directional Attitude::getCurrentAttitude()
+{
+  return m_attitude;
 }


### PR DESCRIPTION
<!-- Please Give Your PR a relevant title-->

## Description of Problem
The current attitude calculation setup is hardcoded to a certain sample rate, which leads to some difficulty in trying to manage other sensors. Additionally, the functions are designed in a monolithic way that would not be operable on a multiprocessing device.

## Solution
- moved the calculations to within a dedicated object
- removed the hardcoded sample rate

## Next Steps
- this should allow for a removal of the sequential GPS->IMU calibration setup, thus substantially reducing the amount of time that the rocket must calibrate on the pad (even for mono-process devices)
- dynamic sample rate can be enabled, potentially increasing attitude precision

## Testing
- no testing done, but unit tests will be added for this later on
