### PR TITLE
remove use of #define #59

### DIFF
--- a/main/config/birdbrain.h
+++ b/main/config/birdbrain.h
@@ -31,5 +31,5 @@ constexpr int PYRO1_PIN = 15;
 
 constexpr int TONE_HZ = 2500; //frequency of buzzer tone
 
-#define GPSSerial Serial1 //Hardware Serial Location of GPS
-#define XBeeSerial Serial //Hardware Serial Location of XBee
+static constexpr double GPSSerial Serial1 //Hardware Serial Location of GPS
+static constexpr double XBeeSerial Serial //Hardware Serial Location of XBee

--- a/main/config/catalyst2.h
+++ b/main/config/catalyst2.h
@@ -28,5 +28,5 @@ constexpr int PYRO1_PIN = 35;
 
 constexpr int TONE_HZ = 1000; //frequency of buzzer tone
 
-#define XBeeSerial Serial1 //Hardware Serial Location of XBee
-#define GPSSerial Serial2 //Hardware Serial Location of GPS
+static constexpr double  XBeeSerial Serial1 //Hardware Serial Location of XBee
+static constexpr double  GPSSerial Serial2 //Hardware Serial Location of GPS

--- a/sensor-testing/BMP_388/BMP_388.ino
+++ b/sensor-testing/BMP_388/BMP_388.ino
@@ -10,7 +10,7 @@
 //#define BMP_SCK 13
 //#define BMP_MISO 12
 //#define BMP_MOSI 11
-#define BMP_CS 10
+static constexpr float BMP_CS = 10
 
 #define SEALEVELPRESSURE_HPA (1013.25)
 

--- a/test/lib/mock_arduino.h
+++ b/test/lib/mock_arduino.h
@@ -3,11 +3,11 @@
 #include <string>
 #include <cstdint>
 
-#define PI 3.1415926535897932384626433832795
-#define BMP3_NO_OVERSAMPLING 1
-#define BMP3_OVERSAMPLING_2X 1
-#define BMP3_IIR_FILTER_COEFF_3 1
-#define BMP3_ODR_100_HZ 1
+static constexpr double  PI = 3.1415926535897932384626433832795
+static constexpr double  BMP3_NO_OVERSAMPLING = 1
+static constexpr double  BMP3_OVERSAMPLING_2X = 1
+static constexpr double  BMP3_IIR_FILTER_COEFF_3 = 1
+static constexpr double  BMP3_ODR_100_HZ = 1
 
 class Adafruit_BMP3XX
 {

--- a/test/test_bmp_altimeter/test_main.cpp
+++ b/test/test_bmp_altimeter/test_main.cpp
@@ -1,10 +1,10 @@
 #include <gtest/gtest.h>
 
 #define XBeeSerial Serial1
-#define BMP_CS 10
-#define SPI1_SCK 11
-#define SPI1_MOSI 12
-#define SPI1_MISO 13
+static constexpr float BMP_CS = 10
+static constexpr float SPI1_SCK = 11
+static constexpr float SPI1_MOSI = 12
+static constexpr float SPI1_MISO = 13
 
 #include "../main/sensors/altimeter/bmp3xx.h"
 


### PR DESCRIPTION
Replace all relevant #define statements with the new method, static constexpr [datatype] , except header file definitions.